### PR TITLE
Removing  ctype_digit checking on values

### DIFF
--- a/src/Index.php
+++ b/src/Index.php
@@ -110,7 +110,7 @@ abstract class Index extends Base
             }
             
             return '('.implode(",", $value).')';
-        } else if (is_int($value) || ctype_digit($value)) {
+        } else if (is_int($value)) {
             return $value;
         }
         


### PR DESCRIPTION
Removing  || ctype_digit($value) since the function considers number leading with zero as integer instead of string